### PR TITLE
[FEATURE] using cwebp binary directly

### DIFF
--- a/Classes/Service/OptimizeImageService.php
+++ b/Classes/Service/OptimizeImageService.php
@@ -3,8 +3,10 @@ namespace Clickstorm\CsWebp\Service;
 
 use TYPO3\CMS\Core\Utility\CommandUtility;
 use TYPO3\CMS\Core\Utility\MathUtility;
+use TYPO3\CMS\Extbase\Utility\DebuggerUtility;
 
 class OptimizeImageService {
+    public $configuration;
 
     /**
      * Initialize
@@ -32,6 +34,9 @@ class OptimizeImageService {
             $webpfile = str_replace("." . $extension, ".webp", $file);
             $quality = MathUtility::forceIntegerInRange($this->configuration['quality'],1,100);
             $command = sprintf('convert %s -quality %s -define webp:lossless=true %s', $file, $quality, $webpfile);
+            if(isset($this->configuration['useCwebp']) && (bool)$this->configuration['useCwebp'] === true){
+                $command = sprintf('%s -q %s %s -o %s', $this->configuration['cwebpPath'], $quality, $file, $webpfile);
+            }
 		}
 
         if (isset($command)) {

--- a/Classes/Service/OptimizeImageService.php
+++ b/Classes/Service/OptimizeImageService.php
@@ -3,7 +3,6 @@ namespace Clickstorm\CsWebp\Service;
 
 use TYPO3\CMS\Core\Utility\CommandUtility;
 use TYPO3\CMS\Core\Utility\MathUtility;
-use TYPO3\CMS\Extbase\Utility\DebuggerUtility;
 
 class OptimizeImageService {
     public $configuration;

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -3,3 +3,9 @@ quality = 65
 
 # cat=basic/debug/1000; type=boolean; label=Enable Debugging. The output goes to backend log module when you are logged in
 debug = 0
+
+# cat=basic; type=boolean; label=Use cwebp instead of imagemagick
+useCwebp = 0
+
+# cat=basic; type=string; label=path to cwebp Binary
+cwebpPath = cwebp

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -14,10 +14,10 @@ $EM_CONF[$_EXTKEY] = [
     'uploadfolder' => false,
     'state' => 'stable',
     'clearCacheOnLoad' => 1,
-    'version' => '1.1.3',
+    'version' => '1.1.2-dev',
     'constraints' => [
         'depends' => [
-            'typo3' => '7.6.0-8.7.99',
+            'typo3' => '7.6.0-7.9.99',
         ],
         'conflicts' => [],
         'suggests' => [],

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -14,10 +14,10 @@ $EM_CONF[$_EXTKEY] = [
     'uploadfolder' => false,
     'state' => 'stable',
     'clearCacheOnLoad' => 1,
-    'version' => '1.1.2-dev',
+    'version' => '1.1.3',
     'constraints' => [
         'depends' => [
-            'typo3' => '7.6.0-7.9.99',
+            'typo3' => '7.6.0-8.7.99',
         ],
         'conflicts' => [],
         'suggests' => [],


### PR DESCRIPTION
it's possible to use the cwebp Encoder form google directly.
so upload the binary to the server and set the Path in Extensionmanager and convert to webp without using imagemagick.
more on https://developers.google.com/speed/webp/docs/cwebp